### PR TITLE
Add JSON config example and minimal reader script

### DIFF
--- a/io/json/hello_json_config.py
+++ b/io/json/hello_json_config.py
@@ -1,0 +1,44 @@
+"""
+Minimaler technischer Referenzfall: JSON-Konfiguration einlesen und auswerten.
+
+Das Skript zeigt bewusst nur die Kernschritte (lesen, interpretieren, ausgeben)
+und verzichtet auf Frameworks oder Zusatzlogik, um als klarer Startpunkt
+für ähnliche Konfigurationsfälle zu dienen.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def load_config(config_path: Path) -> dict:
+    with config_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def format_message(greeting: str, features: list[str]) -> str:
+    message = greeting
+    if "uppercase" in features:
+        message = message.upper()
+    if "exclaim" in features:
+        message = f"{message}!"
+    return message
+
+
+def main() -> None:
+    config_path = Path(__file__).with_name("sample_config.json")
+    config = load_config(config_path)
+
+    greeting = str(config.get("greeting", "Hallo Welt"))
+    repeat = int(config.get("repeat", 1))
+    features = list(config.get("features", []))
+
+    message = format_message(greeting, features)
+
+    for index in range(repeat):
+        print(f"{index + 1}/{repeat}: {message}")
+
+
+if __name__ == "__main__":
+    main()

--- a/io/json/sample_config.json
+++ b/io/json/sample_config.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "Hallo aus JSON",
+  "repeat": 2,
+  "features": ["uppercase", "exclaim"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, self-contained technical reference for reading a JSON configuration and producing console output.
- Mirror the existing example layout (e.g. `ai/gemini`) with an `io/json` example directory.
- Show a simple feature-flag and repetition pattern (fields: `greeting`, `repeat`, `features`) for basic config-driven behavior.

### Description
- Add `io/json/sample_config.json` containing `greeting`, `repeat`, and `features` example fields.
- Add `io/json/hello_json_config.py` which uses the standard library `json` and `pathlib` to load and parse the config.
- Implement `load_config`, `format_message`, and `main` where `format_message` applies `features` like `uppercase` and `exclaim`, and `main` honors the `repeat` count.
- Include a module docstring that describes the file as a minimal technical reference case.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0f346bd08332a1d8fad96791becc)